### PR TITLE
Fix #315

### DIFF
--- a/project/runtime-bukkit/src/main/kotlin/me/arasple/mc/trchat/module/internal/data/PlayerData.kt
+++ b/project/runtime-bukkit/src/main/kotlin/me/arasple/mc/trchat/module/internal/data/PlayerData.kt
@@ -36,7 +36,7 @@ class PlayerData(val player: OfflinePlayer) {
 
     val isVanishing get() = player.getDataContainer()["vanish"].cbool
 
-    val ignored get() = player.getDataContainer()["ignored"]?.split(",")?.map { it.toUUID() } ?: emptyList()
+    val ignored get() = player.getDataContainer()["ignored"]?.split(",")?.filter { it.isNotBlank() }?.map { it.toUUID() } ?: emptyList()
 
     fun setChannel(channel: Channel) {
         player.getDataContainer()["channel"] = channel.id


### PR DESCRIPTION
Fix #315 
看起来解除所有玩家的ignore后会导致ignored为空字符串
此时再以 , 分割并转换UUID时可能会尝试进行 空字符串转UUID操作 并抛出
IllegalArgumentException: Illegal UUID string: