### PR TITLE
修复(rainbow/gradient): 渐变时 emoji 字符被拆分问题

### DIFF
--- a/project/runtime-bukkit/src/main/java/me/arasple/mc/trchat/util/color/HexUtils.java
+++ b/project/runtime-bukkit/src/main/java/me/arasple/mc/trchat/util/color/HexUtils.java
@@ -106,33 +106,31 @@ public final class HexUtils {
 
             int stop = findStop(parsed, matcher.end());
             String content = parsed.substring(matcher.end(), stop);
-            int contentLength = content.length();
-            char[] chars = content.toCharArray();
-            for (int i = 0; i < chars.length - 1; i++)
-                if (chars[i] == '&' && "KkLlMmNnOoRr".indexOf(chars[i + 1]) > -1)
-                    contentLength -= 2;
 
-            int length = looping ? Math.min(contentLength, CHARS_UNTIL_LOOP) : contentLength;
+            // 使用 codePoint 遍历，避免 emoji 被拆开
+            int length = content.codePointCount(0, content.length());
+            if (looping) length = Math.min(length, CHARS_UNTIL_LOOP);
 
-            ColorGenerator rainbow;
-            if (speed == -1) {
-                rainbow = new Rainbow(length, saturation, brightness);
-            } else {
-                rainbow = new AnimatedRainbow(length, saturation, brightness, speed);
-            }
+            ColorGenerator rainbow = (speed == -1)
+                    ? new Rainbow(length, saturation, brightness)
+                    : new AnimatedRainbow(length, saturation, brightness, speed);
 
             String compoundedFormat = ""; // Carry the format codes through the rainbow gradient
-            for (int i = 0; i < chars.length; i++) {
-                char c = chars[i];
-                if (c == '&' && i + 1 < chars.length) {
-                    char next = chars[i + 1];
+            for (int i = 0; i < content.length(); ) {
+                int cp = content.codePointAt(i);
+                int charCount = Character.charCount(cp);
+
+                if (cp == '&' && i + 1 < content.length()) {
+                    char next = content.charAt(i + 1);
                     if (HexKt.isFormat(next)) {
                         compoundedFormat += String.valueOf(ChatColor.COLOR_CHAR) + next;
-                        i++; // Skip next character
+                        i += 2; // Skip next character
                         continue;
                     }
                 }
-                parsedRainbow.append(rainbow.nextChatColor()).append(compoundedFormat).append(c);
+
+                parsedRainbow.append(rainbow.nextChatColor()).append(compoundedFormat).appendCodePoint(cp);
+                i += charCount;
             }
 
             String before = parsed.substring(0, matcher.start());
@@ -168,32 +166,30 @@ public final class HexUtils {
 
             int stop = findStop(parsed, matcher.end());
             String content = parsed.substring(matcher.end(), stop);
-            int contentLength = content.length();
-            char[] chars = content.toCharArray();
-            for (int i = 0; i < chars.length - 1; i++)
-                if (chars[i] == '&' && "KkLlMmNnOoRr".indexOf(chars[i + 1]) > -1)
-                    contentLength -= 2;
 
-            int length = looping ? Math.min(contentLength, CHARS_UNTIL_LOOP) : contentLength;
-            ColorGenerator gradient;
-            if (speed == -1) {
-                gradient = new Gradient(hexSteps, length);
-            } else {
-                gradient = new AnimatedGradient(hexSteps, length, speed);
-            }
+            int length = content.codePointCount(0, content.length());
+            if (looping) length = Math.min(length, CHARS_UNTIL_LOOP);
+
+            ColorGenerator gradient = (speed == -1)
+                    ? new Gradient(hexSteps, length)
+                    : new AnimatedGradient(hexSteps, length, speed);
 
             String compoundedFormat = ""; // Carry the format codes through the gradient
-            for (int i = 0; i < chars.length; i++) {
-                char c = chars[i];
-                if (c == '&' && i + 1 < chars.length) {
-                    char next = chars[i + 1];
+            for (int i = 0; i < content.length(); ) {
+                int cp = content.codePointAt(i);
+                int charCount = Character.charCount(cp);
+
+                if (cp == '&' && i + 1 < content.length()) {
+                    char next = content.charAt(i + 1);
                     if (HexKt.isFormat(next)) {
                         compoundedFormat += String.valueOf(ChatColor.COLOR_CHAR) + next;
-                        i++; // Skip next character
+                        i += 2; // Skip next character
                         continue;
                     }
                 }
-                parsedGradient.append(gradient.nextChatColor()).append(compoundedFormat).append(c);
+
+                parsedGradient.append(gradient.nextChatColor()).append(compoundedFormat).appendCodePoint(cp);
+                i += charCount;
             }
 
             String before = parsed.substring(0, matcher.start());


### PR DESCRIPTION
# 修复(rainbow/gradient): 渐变时 emoji 字符被拆分问题

## 变更说明

本次修改针对 `parseRainbow` 和 `parseGradients` 的渐变功能做了优化，主要解决 **渐变时 emoji 字符被拆分**的问题：

- 将字符遍历方式改为 **按 `codePoint` 遍历**，避免大部分 emoji 被拆分
- 渐变颜色在大部分 emoji 上保持连续
- **注意**：ZWJ 连接的复杂 emoji（如 👨‍👩‍👧‍👦）会被拆分，目前未完全支持  

## 修改前效果
<img width="455" height="101" alt="0e9942c0-2c37-4f56-85d4-ab4131539d60" src="https://github.com/user-attachments/assets/45f3eb69-1900-4265-83de-2ba91bf50ec1" />
<img width="493" height="102" alt="4a0908fb-cd88-4a3f-906f-d87d58916690" src="https://github.com/user-attachments/assets/76403eeb-7aa1-4dad-b815-064a4867abaa" />


## 修改后效果
<img width="432" height="103" alt="2d917b4e-bf6a-4c84-abb1-2e03b7b4772e" src="https://github.com/user-attachments/assets/e24de3d2-2435-441c-b8d9-69d4e176c7c9" />
<img width="490" height="103" alt="ae0ba35e-4bf9-4b25-a3f9-f817ed6399b2" src="https://github.com/user-attachments/assets/2dc17909-c633-45e6-adf2-229c51dafd6a" />

## 测试说明

- 对包含普通字符、单个 emoji、组合 emoji 的文本进行了测试  
- 确认渐变颜色连续，原有格式代码(`&` + 颜色/样式)仍可生效  
- ZWJ 复杂 emoji （如 👨‍👩‍👧‍👦）测试仍可能拆分，属于已知限制

## 备注

本次修改 **不影响原有逻辑和格式代码**，仅修改了遍历字符方式。
