### PR TITLE
feat(sign): 禁止无发言权限的玩家编辑告示牌

### DIFF
--- a/project/runtime-bukkit/src/main/kotlin/me/arasple/mc/trchat/module/display/function/standard/InventoryShow.kt
+++ b/project/runtime-bukkit/src/main/kotlin/me/arasple/mc/trchat/module/display/function/standard/InventoryShow.kt
@@ -134,10 +134,11 @@ object InventoryShow : Function("INVENTORY") {
                 })
                 inv.setItem(3, inventory.itemInHand.replaceAir())
                 inv.setItem(4, PLACEHOLDER_ITEM)
-                inv.setItem(5, inventory.getItem(inventory.size - 2).replaceAir())
-                inv.setItem(6, inventory.getItem(inventory.size - 3).replaceAir())
-                inv.setItem(7, inventory.getItem(inventory.size - 4).replaceAir())
-                inv.setItem(8, inventory.getItem(inventory.size - 5).replaceAir())
+                val armor = inventory.armorContents
+                inv.setItem(5, armor[3].replaceAir()) // 头盔
+                inv.setItem(6, armor[2].replaceAir()) // 胸甲
+                inv.setItem(7, armor[1].replaceAir()) // 护腿
+                inv.setItem(8, armor[0].replaceAir()) // 靴子
                 (9..17).forEach { slot -> inv.setItem(slot, PLACEHOLDER_ITEM) }
             }
             onClick(lock = true)

--- a/project/runtime-bukkit/src/main/kotlin/me/arasple/mc/trchat/module/internal/listener/ListenerSignChange.kt
+++ b/project/runtime-bukkit/src/main/kotlin/me/arasple/mc/trchat/module/internal/listener/ListenerSignChange.kt
@@ -2,9 +2,13 @@ package me.arasple.mc.trchat.module.internal.listener
 
 import me.arasple.mc.trchat.TrChat
 import me.arasple.mc.trchat.module.adventure.toAdventure
+import io.papermc.paper.event.player.PlayerOpenSignEvent
 import me.arasple.mc.trchat.module.internal.TrChatBukkit
+import me.arasple.mc.trchat.util.data
+import me.arasple.mc.trchat.util.session
 import me.arasple.mc.trchat.util.color.MessageColors
 import me.arasple.mc.trchat.util.parseSimple
+import org.bukkit.entity.Player
 import org.bukkit.event.block.SignChangeEvent
 import taboolib.common.platform.Platform
 import taboolib.common.platform.PlatformSide
@@ -12,6 +16,7 @@ import taboolib.common.platform.event.EventPriority
 import taboolib.common.platform.event.SubscribeEvent
 import taboolib.common.platform.function.adaptPlayer
 import taboolib.module.configuration.ConfigNode
+import taboolib.platform.util.sendLang
 
 /**
  * @author ItsFlicker
@@ -52,5 +57,21 @@ object ListenerSignChange {
                 e.setLine(index, MessageColors.replaceWithPermission(p, edited, MessageColors.Type.SIGN))
             }
         }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onPlayerOpenSign(e: PlayerOpenSignEvent) {
+        val player = e.player
+        if (!player.hasPermission("trchat.bypass.signedit") && !canSpeak(player)) {
+            e.isCancelled = true
+            player.sendLang("Sign-Edit-No-Permission")
+        }
+    }
+
+    private fun canSpeak(player: Player): Boolean {
+        if (TrChatBukkit.isGlobalMuting && !player.hasPermission("trchat.bypass.globalmute")) return false
+        if (player.data.isMuted) return false
+        val channel = player.session.getChannel()
+        return channel == null || channel.canSpeak(player)
     }
 }

--- a/project/runtime-bukkit/src/main/kotlin/me/arasple/mc/trchat/module/internal/listener/ListenerSignChange.kt
+++ b/project/runtime-bukkit/src/main/kotlin/me/arasple/mc/trchat/module/internal/listener/ListenerSignChange.kt
@@ -29,6 +29,9 @@ object ListenerSignChange {
     var filter = true
         private set
 
+    @ConfigNode("Chat.Sign-Edit-Permission-Check", "settings.yml")
+    var signEditPermissionCheck = true
+
     @ConfigNode("Color.Sign", "settings.yml")
     var color = true
         private set
@@ -61,6 +64,7 @@ object ListenerSignChange {
 
     @SubscribeEvent(priority = EventPriority.LOW, ignoreCancelled = true)
     fun onPlayerOpenSign(e: PlayerOpenSignEvent) {
+        if (!signEditPermissionCheck) return
         val player = e.player
         if (!player.hasPermission("trchat.bypass.signedit") && !canSpeak(player)) {
             e.isCancelled = true

--- a/project/runtime-bukkit/src/main/resources/lang/en_US.yml
+++ b/project/runtime-bukkit/src/main/resources/lang/en_US.yml
@@ -224,6 +224,13 @@ Channel-Bad-Language:
     sound: 'ENTITY_ITEM_BREAK'
     volume: 1
     pitch: 0
+Sign-Edit-No-Permission:
+  - type: actionbar
+    text: '&cNo Edit Sign Permission'
+  - type: sound
+    sound: 'ENTITY_ITEM_BREAK'
+    volume: 1
+    pitch: 0
 
 Mute-Muted-Player: '&8[&3Tr&bChat&8] &7You muted {0} for {1}.Reason: {2}'
 Mute-Cancel-Muted-Player: '&8[&3Tr&bChat&8] &7You cancelled muting {0}.'

--- a/project/runtime-bukkit/src/main/resources/lang/es_ES.yml
+++ b/project/runtime-bukkit/src/main/resources/lang/es_ES.yml
@@ -217,6 +217,13 @@ Channel-Bad-Language:
     sound: 'ENTITY_ITEM_BREAK'
     volume: 1
     pitch: 0
+Sign-Edit-No-Permission:
+  - type: actionbar
+    text: '&cNo Edit Sign Permission'
+  - type: sound
+    sound: 'ENTITY_ITEM_BREAK'
+    volume: 1
+    pitch: 0
 
 Mute-Muted-Player: '&8[&3Tr&bChat&8] &7Fuiste silenciado por {0}, el tiempo de {1}.Razón: {2}'
 Mute-Cancel-Muted-Player: '&8[&3Tr&bChat&8] &7El silencio fue cancelado {0}.'

--- a/project/runtime-bukkit/src/main/resources/lang/zh_CN.yml
+++ b/project/runtime-bukkit/src/main/resources/lang/zh_CN.yml
@@ -227,6 +227,13 @@ Channel-Bad-Language:
     sound: 'ENTITY_ITEM_BREAK'
     volume: 1
     pitch: 0
+Sign-Edit-No-Permission:
+  - type: actionbar
+    text: '&c你没有权限编辑告示牌'
+  - type: sound
+    sound: 'ENTITY_ITEM_BREAK'
+    volume: 1
+    pitch: 0
 
 Mute-Muted-Player: '&8[&3Tr&bChat&8] &7你已禁言 {0} {1}.原因: {2}'
 Mute-Cancel-Muted-Player: '&8[&3Tr&bChat&8] &7你已取消禁言 {0}.'

--- a/project/runtime-bukkit/src/main/resources/settings.yml
+++ b/project/runtime-bukkit/src/main/resources/settings.yml
@@ -38,6 +38,7 @@ Chat:
   Anti-Repeat: 0.85
   Cooldown: '2.0s'
   Length-Limit: 100
+  Sign-Edit-Permission-Check: false
 
 Color:
   Chat: true


### PR DESCRIPTION
- 添加 PlayerOpenSignEvent 监听，检查禁言/频道权限

- 添加配置项 Enable.Sign-Edit-Permission-Check

- 添加语言消息 Sign-Edit-No-Permission

fix(inventory): 修复背包展示中盔甲顺序错误

- 使用 armorContents 数组替代原 slot 计算方式