### PR TITLE
玩家完成书与笔编辑时检查发言权限

### DIFF
--- a/project/runtime-bukkit/src/main/kotlin/me/arasple/mc/trchat/module/internal/listener/ListenerBookEdit.kt
+++ b/project/runtime-bukkit/src/main/kotlin/me/arasple/mc/trchat/module/internal/listener/ListenerBookEdit.kt
@@ -1,12 +1,17 @@
 package me.arasple.mc.trchat.module.internal.listener
 
+import me.arasple.mc.trchat.module.internal.TrChatBukkit
 import me.arasple.mc.trchat.util.color.MessageColors
+import me.arasple.mc.trchat.util.data
+import me.arasple.mc.trchat.util.session
+import org.bukkit.entity.Player
 import org.bukkit.event.player.PlayerEditBookEvent
 import taboolib.common.platform.Platform
 import taboolib.common.platform.PlatformSide
 import taboolib.common.platform.event.EventPriority
 import taboolib.common.platform.event.SubscribeEvent
 import taboolib.module.configuration.ConfigNode
+import taboolib.platform.util.sendLang
 
 /**
  * @author ItsFlicker
@@ -19,6 +24,9 @@ object ListenerBookEdit {
     var color = true
         private set
 
+    @ConfigNode("Chat.Permission-Check.Book", "settings.yml")
+    var bookEditPermissionCheck = false
+
     @Suppress("Deprecation")
     @SubscribeEvent(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     fun onBookEdit(e: PlayerEditBookEvent) {
@@ -28,5 +36,22 @@ object ListenerBookEdit {
             meta.pages = MessageColors.replaceWithPermission(p, meta.pages, MessageColors.Type.BOOK)
         }
         e.newBookMeta = meta
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onBookEditCheck(e: PlayerEditBookEvent) {
+        if (!bookEditPermissionCheck) return
+        val player = e.player
+        if (!player.hasPermission("trchat.bypass.bookedit") && !canSpeak(player)) {
+            e.isCancelled = true
+            player.sendLang("Book-Edit-No-Permission")
+        }
+    }
+
+    private fun canSpeak(player: Player): Boolean {
+        if (TrChatBukkit.isGlobalMuting && !player.hasPermission("trchat.bypass.globalmute")) return false
+        if (player.data.isMuted) return false
+        val channel = player.session.getChannel()
+        return channel == null || channel.canSpeak(player)
     }
 }

--- a/project/runtime-bukkit/src/main/kotlin/me/arasple/mc/trchat/module/internal/listener/ListenerSignChange.kt
+++ b/project/runtime-bukkit/src/main/kotlin/me/arasple/mc/trchat/module/internal/listener/ListenerSignChange.kt
@@ -29,7 +29,7 @@ object ListenerSignChange {
     var filter = true
         private set
 
-    @ConfigNode("Chat.Sign-Edit-Permission-Check", "settings.yml")
+    @ConfigNode("Chat.Permission-Check.Sign", "settings.yml")
     var signEditPermissionCheck = false
 
     @ConfigNode("Color.Sign", "settings.yml")

--- a/project/runtime-bukkit/src/main/resources/lang/en_US.yml
+++ b/project/runtime-bukkit/src/main/resources/lang/en_US.yml
@@ -226,7 +226,14 @@ Channel-Bad-Language:
     pitch: 0
 Sign-Edit-No-Permission:
   - type: actionbar
-    text: '&cNo Edit Sign Permission'
+    text: '&cYou do not have permission to edit the bulletin board.'
+  - type: sound
+    sound: 'ENTITY_ITEM_BREAK'
+    volume: 1
+    pitch: 0
+Book-Edit-No-Permission:
+  - type: actionbar
+    text: '&cYou do not have permission to edit the book.'
   - type: sound
     sound: 'ENTITY_ITEM_BREAK'
     volume: 1

--- a/project/runtime-bukkit/src/main/resources/lang/es_ES.yml
+++ b/project/runtime-bukkit/src/main/resources/lang/es_ES.yml
@@ -219,7 +219,14 @@ Channel-Bad-Language:
     pitch: 0
 Sign-Edit-No-Permission:
   - type: actionbar
-    text: '&cNo Edit Sign Permission'
+    text: '&cYou do not have permission to edit the bulletin board.'
+  - type: sound
+    sound: 'ENTITY_ITEM_BREAK'
+    volume: 1
+    pitch: 0
+Book-Edit-No-Permission:
+  - type: actionbar
+    text: '&cYou do not have permission to edit the book.'
   - type: sound
     sound: 'ENTITY_ITEM_BREAK'
     volume: 1

--- a/project/runtime-bukkit/src/main/resources/lang/zh_CN.yml
+++ b/project/runtime-bukkit/src/main/resources/lang/zh_CN.yml
@@ -234,6 +234,13 @@ Sign-Edit-No-Permission:
     sound: 'ENTITY_ITEM_BREAK'
     volume: 1
     pitch: 0
+Book-Edit-No-Permission:
+  - type: actionbar
+    text: '&c你没有权限编辑书与笔'
+  - type: sound
+    sound: 'ENTITY_ITEM_BREAK'
+    volume: 1
+    pitch: 0
 
 Mute-Muted-Player: '&8[&3Tr&bChat&8] &7你已禁言 {0} {1}.原因: {2}'
 Mute-Cancel-Muted-Player: '&8[&3Tr&bChat&8] &7你已取消禁言 {0}.'

--- a/project/runtime-bukkit/src/main/resources/settings.yml
+++ b/project/runtime-bukkit/src/main/resources/settings.yml
@@ -38,7 +38,9 @@ Chat:
   Anti-Repeat: 0.85
   Cooldown: '2.0s'
   Length-Limit: 100
-  Sign-Edit-Permission-Check: false
+  Permission-Check:
+    Sign: false #无发言权限无法编辑告示牌 true 开启 false关闭
+    Book: false #无发言权限无法编辑书与笔 true 开启 false关闭
 
 Color:
   Chat: true


### PR DESCRIPTION
- 新增配置项 Chat.Book-Edit-Permission-Check
- 新增权限节点 trchat.bypass.bookedit
- 添加语言消息 Book-Edit-No-Permission