### PR TITLE
支持 Minecraft 26.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ subprojects {
 //            disableOnUnsupportedVersion = false
         }
         version {
-            taboolib = "6.3.0-b0ee24a"
+            taboolib = "6.3.0-4bced1a"
             coroutines = null
         }
     }


### PR DESCRIPTION
## 改动说明

- 将 TabooLib 从 6.3.0-b0ee24a 升级到 6.3.0-4bced1a
- 新版本已支持识别 Minecraft 26.2，并将版本号映射为 260200
- 26.2 继续复用现有 NMSImpl260100；TabooLib 的稳定 NMS 模块同样继续使用 v260100 编译基线，因此无需增加重复实现

## 验证结果

- 运行 gradlew.bat clean build --refresh-dependencies --stacktrace，构建成功
- 在 Java 25、Paper 26.2 build 60 上完成实际启动测试
- TrChat v2.4.5 正常启用，并选择 NMSImpl260100
- 服务器正常进入 Done，启动日志中无 TrChat 相关异常