### PR TITLE
修复 Minecraft 26.2 聊天与 CMI 重复消息问题

### DIFF
--- a/project/module-chat/src/main/kotlin/taboolib/module/chat/impl/AdventureComponent.kt
+++ b/project/module-chat/src/main/kotlin/taboolib/module/chat/impl/AdventureComponent.kt
@@ -166,12 +166,12 @@ class AdventureComponent() : ComponentText {
 
     override fun click(action: ClickAction, value: String): ComponentText {
         when (action) {
-            ClickAction.OPEN_URL,
-            ClickAction.OPEN_FILE,
-            ClickAction.RUN_COMMAND,
-            ClickAction.SUGGEST_COMMAND,
-            ClickAction.CHANGE_PAGE,
-            ClickAction.COPY_TO_CLIPBOARD -> latest.clickEvent(ClickEvent.clickEvent(ClickEvent.Action.valueOf(action.name), value))
+            ClickAction.OPEN_URL -> latest.clickEvent(ClickEvent.openUrl(value))
+            ClickAction.OPEN_FILE -> latest.clickEvent(ClickEvent.openFile(value))
+            ClickAction.RUN_COMMAND -> latest.clickEvent(ClickEvent.runCommand(value))
+            ClickAction.SUGGEST_COMMAND -> latest.clickEvent(ClickEvent.suggestCommand(value))
+            ClickAction.CHANGE_PAGE -> latest.clickEvent(ClickEvent.changePage(value.toInt()))
+            ClickAction.COPY_TO_CLIPBOARD -> latest.clickEvent(ClickEvent.copyToClipboard(value))
             // 插入文本
             ClickAction.INSERTION -> clickInsertText(value)
         }

--- a/project/runtime-bukkit/src/main/kotlin/me/arasple/mc/trchat/module/internal/listener/ListenerChat.kt
+++ b/project/runtime-bukkit/src/main/kotlin/me/arasple/mc/trchat/module/internal/listener/ListenerChat.kt
@@ -15,6 +15,7 @@ import taboolib.common.platform.event.EventPriority
 import taboolib.common.platform.event.SubscribeEvent
 import taboolib.module.configuration.ConfigNode
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * @author ItsFlicker
@@ -27,12 +28,15 @@ object ListenerChat {
     var cancelEvent = false
         private set
 
-    private val cachePrefix = mutableMapOf<UUID, String>()
+    private val cachePrefix = ConcurrentHashMap<UUID, String>()
+    private val claimedPaperChats = ConcurrentHashMap.newKeySet<UUID>()
 
     @Ghost
-    @SubscribeEvent(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    @SubscribeEvent(priority = EventPriority.HIGHEST, ignoreCancelled = false)
     fun onPaperChat(e: AsyncChatEvent) {
         if (!TrChatBukkit.isPaperEnv) return
+        val claimed = claimedPaperChats.remove(e.player.uniqueId)
+        if (e.isCancelled && !claimed) return
         if (cancelEvent) {
             e.isCancelled = true
         } else {
@@ -55,21 +59,30 @@ object ListenerChat {
         }
     }
 
-    @SubscribeEvent(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    fun onBukkitChat(e: AsyncPlayerChatEvent) {
-        // 提前判定前缀
-        if (TrChatBukkit.isPaperEnv) {
-            Channel.channels.values.forEach { channel ->
-                channel.bindings.prefix?.forEach {
-                    if (e.message.startsWith(it, ignoreCase = true)) {
-                        cachePrefix[e.player.uniqueId] = channel.id
-                        e.message = e.message.substring(it.length)
-                        return
-                    }
+    @SubscribeEvent(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    fun onPaperLegacyChat(e: AsyncPlayerChatEvent) {
+        if (!TrChatBukkit.isPaperEnv) return
+
+        if (cancelEvent) {
+            claimedPaperChats += e.player.uniqueId
+            e.isCancelled = true
+        } else {
+            e.recipients.clear()
+        }
+        Channel.channels.values.forEach { channel ->
+            channel.bindings.prefix?.forEach {
+                if (e.message.startsWith(it, ignoreCase = true)) {
+                    cachePrefix[e.player.uniqueId] = channel.id
+                    e.message = e.message.substring(it.length)
+                    return
                 }
             }
-            return
         }
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onBukkitChat(e: AsyncPlayerChatEvent) {
+        if (TrChatBukkit.isPaperEnv) return
         if (e.isCancelled) return
         if (cancelEvent) {
             e.isCancelled = true


### PR DESCRIPTION
## 改动内容

- 修复 Minecraft 26.2 / Adventure 新版中 `ClickEvent.Action.valueOf(String)` 不再存在导致聊天事件抛出 `NoSuchMethodError` 的问题。
- 点击动作改用 Adventure 稳定的工厂方法，覆盖打开链接、打开文件、执行命令、建议命令、翻页和复制到剪贴板。
- 修正 Paper 环境下 `Options.Always-Cancel-Chat-Event` 的独占语义：
  - 在兼容层 `AsyncPlayerChatEvent` 的 `LOWEST` 阶段取消事件，使 CMI 等旧版聊天处理器在格式化、过滤和广播前直接跳过。
  - 记录由 TrChat 主动认领的聊天，避免把其他插件取消的消息错误恢复。
  - 在现代 `AsyncChatEvent` 的 `HIGHEST` 阶段仅恢复 TrChat 主动认领的消息，并由 TrChat 完成频道处理与发送。
  - 独占模式关闭时仍沿用清空旧事件接收者的兼容行为，避免重复广播。
- 将跨事件频道前缀缓存改为 `ConcurrentHashMap`，避免异步聊天并发访问普通 `HashMap`。

Fixes #557

## 测试环境

- 服务端：Paper 26.2 build 60 beta
- Java：25.0.2
- TrChat：基于 v2.4.5 的本分支构建
- CMI：9.8.8.5
- CMILib：1.5.9.7
- PlaceholderAPI：2.12.3
- 两名玩家同时在线测试
- TrChat `Always-Cancel-Chat-Event: true`
- CMI `ModifyChatFormat.Enabled: false`
- CMI `ClickHoverMessages: true`，刻意保留冲突配置验证 TrChat 独占聊天处理

## 测试结果

- [x] 执行 `./gradlew clean build`，完整构建成功。
- [x] 严格接管版本部署到 Paper 26.2，服务端正常启动，TrChat 成功加载 NMS 实现、12 个聊天功能和 4 个聊天频道。
- [x] 两名玩家分别发送普通聊天，双方均只收到一条由 TrChat 格式化的消息。
- [x] 测试 `@cowb002` 玩家提醒，提醒与聊天渲染正常，未出现重复消息。
- [x] 测试手持潜影盒物品展示，聊天中正确显示 `[Shulker Box x1]`，物品悬浮信息正常。
- [x] 测试包含点击命令的默认聊天格式，组件正常生成，不再出现 `ClickEvent.Action.valueOf` 的 `NoSuchMethodError`。
- [x] 执行 `/tell xiaoyiluck 11` 验证私聊入口，命令正常处理。
- [x] CMI 保持 `ClickHoverMessages: true` 时不再参与公共聊天广播，聊天输出由 TrChat 接管。
- [x] 后台未出现 `ERROR`、异常栈、`Could not pass event` 或聊天事件投递失败。