### PR TITLE
修复 Folia 下无法正确发送头像消息的问题

### DIFF
--- a/project/module-nms/src/main/kotlin/me/arasple/mc/trchat/api/nms/NMSImpl.kt
+++ b/project/module-nms/src/main/kotlin/me/arasple/mc/trchat/api/nms/NMSImpl.kt
@@ -61,7 +61,11 @@ class NMSImpl : NMS() {
     }
 
     override fun sendMessage(receiver: Player, component: ComponentText, sender: UUID?, usePacket: Boolean) {
-        if (!usePacket || Folia.isFolia || ServerUtil.isModdedServer) {
+        if (Folia.isFolia) {
+            (receiver as net.kyori.adventure.audience.Audience).sendMessage(component.toAdventureObject())
+            return
+        }
+        if (!usePacket || ServerUtil.isModdedServer) {
             component.sendTo(adaptPlayer(receiver))
             return
         }

--- a/project/module-nms/src/main/kotlin/me/arasple/mc/trchat/api/nms/NMSImpl12005.kt
+++ b/project/module-nms/src/main/kotlin/me/arasple/mc/trchat/api/nms/NMSImpl12005.kt
@@ -25,7 +25,11 @@ class NMSImpl12005 : NMS() {
     }
 
     override fun sendMessage(receiver: Player, component: ComponentText, sender: UUID?, usePacket: Boolean) {
-        if (!usePacket || Folia.isFolia || ServerUtil.isModdedServer) {
+        if (Folia.isFolia) {
+            (receiver as net.kyori.adventure.audience.Audience).sendMessage(component.toAdventureObject())
+            return
+        }
+        if (!usePacket || ServerUtil.isModdedServer) {
             component.sendTo(adaptPlayer(receiver))
             return
         }

--- a/project/module-nms/v26/src/main/kotlin/me/arasple/mc/trchat/api/nms/NMSImpl260100.kt
+++ b/project/module-nms/v26/src/main/kotlin/me/arasple/mc/trchat/api/nms/NMSImpl260100.kt
@@ -25,7 +25,11 @@ class NMSImpl260100 : NMS() {
     }
 
     override fun sendMessage(receiver: Player, component: ComponentText, sender: UUID?, usePacket: Boolean) {
-        if (!usePacket || Folia.isFolia || ServerUtil.isModdedServer) {
+        if (Folia.isFolia) {
+            (receiver as net.kyori.adventure.audience.Audience).sendMessage(component.toAdventureObject())
+            return
+        }
+        if (!usePacket || ServerUtil.isModdedServer) {
             component.sendTo(adaptPlayer(receiver))
             return
         }


### PR DESCRIPTION
Folia 下直接通过 Adventure Audience.sendMessage() 发送组件，避免经过 TabooLib 的 Bungee RawMessage 转换，保留 head 的 texture 信息实现修复 https://github.com/TrPlugins/TrChat/issues/525